### PR TITLE
gh actions: update java to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 14
 
       # Check out current repository
       - name: Fetch Sources
@@ -89,7 +89,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 14
 
       # Check out current repository
       - name: Fetch Sources
@@ -152,7 +152,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 14
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 14
 
       # Check out current repository
       - name: Fetch Sources
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 14
 
       # Check out current repository
       - name: Fetch Sources


### PR DESCRIPTION
The plugin doesn't build with Java 8, upgrading to 14 which is the recommended version in use at Brex